### PR TITLE
Fixed Pass/FailPTR record

### DIFF
--- a/Semi_ATE/STDF/PTR.py
+++ b/Semi_ATE/STDF/PTR.py
@@ -128,31 +128,28 @@ Location:
 #            1 = Test completed with no pass/fail indication
 
         v = self.get_fields(6)[3] 
-        if v != None and v[6] == '1':
-            buff += ' '
-        elif v != None and v[6] == '0':
-            test_status = 'Unknown'
-#            TEST_FLG
-#            bit 7:
-#                0 = Test passed
-#                1 = Test failed
-
-            if v[7] == '0':
-                buff += 'P'
-                test_status = 'P'
-            elif v[7] == '1':
-                buff += 'F'
-                test_status = 'F'
-
-#       7    PARM_FLG
-#            bit 5:
+        if v != None:
+            if v[6] == '1':
+                buff += ' '
+            elif v[6] == '0':
+                test_status = 'Unknown'
+#               TEST_FLG
+#               bit 7:
+#                   0 = Test passed (ignore value, go to PARM_FLG bit 5)
+#                   1 = Test failed
+                if v[7] == '1':
+                    buff += 'F'
+                else:
+#                PARM_FLG
+#                bit 5:
 #                0 = Test failed or test passed standard limits
 #                1 = Test passed alternate limits
-            v = self.get_fields(7)[3] 
-            if v != None and v[5] == '0':
-                buff += test_status
-            elif v != None and [5] == '1':
-                buff += 'A'
+                    v = self.get_fields(7)[3] 
+                    if v != None:
+                        if v[5] == '0':
+                            buff += 'P'
+                        elif v[5] == '1':
+                            buff += 'A'
         body += "%s|" % buff
 #        Alarm Flags:
 #            TEST_FLG bits 0, 2, 3, 4 & 5


### PR DESCRIPTION
Fixed Pass/Fail Flag in the PTR ATDF record.
The following logic was implemented:
1. If TEST_FLG bit 6 value is 1 -> the output is empty space ' ' (Test completed without pass/fail indication). END.
2. If TEST_FLG bit 6 value is 0, that means that bit 7 is valid. Continue to point 3.
3. If TEST_FLG bit 7 value is 1 -> the output value is 'F' (Test failed). END.
4. If TEST_FLG bit 7 value is 0, the value from PARM_FLG bit 5 will be taken. Continue to point 5.
5. If PARM_FLG bit 5 value is 0 -> the output is 'P' (Test failed or test passed standard limits). END.
6. If PARM_FLG bit 5 value is 1 -> the output is 'A' (Test passed alternate limits). END.