### PR TITLE
Seimit issue 40

### DIFF
--- a/Semi_ATE/STDF/STDR.py
+++ b/Semi_ATE/STDF/STDR.py
@@ -598,7 +598,21 @@ class STDR(ABC):
                     # TODO: OK, but why strip first, just to pad again? common value for "C*1" is a single space ' ', but "C*n" is usually not filled with spaces, is it?
                     temp = temp.ljust(int(Bytes), ' ')
                 elif Bytes == 'n':
-                    temp = Value.strip()[:255]
+                    # issue 40 : removing unicode chars from the STDF, because STDF supports only ASCII
+                    # We can not use the extended ASCII (like Latin-1), because in STDF spec is written:
+                    # ASCII : (American Standard Code for Information Interchange) A code, using seven bit plus
+                    # parity, established by the American National Standards Institute (ANSI) to achieve
+                    # compatibility between devices exchanging character oriented data.
+                    # None ASCCI characters will be replaced with empty string
+                    new_value = ''
+                    count = 0
+                    for c in Value:
+                        if ord(c) > 127:
+                            new_value += ' '
+                        else:
+                            new_value += Value[count]
+                        count += 1
+                    temp = new_value.strip()[:255]
                 elif Bytes == 'f':
                     raise STDFError("%s.set_value(%s, %s) : Unimplemented type '%s'" % (self.id, FieldKey, Value, '*'.join((Type, Bytes))))
                 else:

--- a/tests/test_PTR.py
+++ b/tests/test_PTR.py
@@ -135,10 +135,11 @@ def ptr(endian):
     record.set_value('HI_LIMIT', hi_limit)
     rec_len += 4;
 
-    units = 'mV'
-    record.set_value('UNITS', units)
-    rec_len += len(units) + 1;
-    expected_atdf += str(units) + "|"
+    unicode_units = '°C'
+    ascii_units = 'C'
+    record.set_value('UNITS', unicode_units)
+    rec_len += len(ascii_units) + 1;
+    expected_atdf += str(ascii_units) + "|"
 
     expected_atdf += str(lo_limit) + "|"
     expected_atdf += str(hi_limit) + "|"
@@ -215,8 +216,8 @@ def ptr(endian):
 #   Test HI_LIMIT, expected value hi_limit
     stdfRecTest.assert_float(hi_limit)
 #   Test UNITS, expected value units
-    stdfRecTest.assert_ubyte(len(units))
-    stdfRecTest.assert_char_array(len(units), units)
+    stdfRecTest.assert_ubyte(len(ascii_units))
+    stdfRecTest.assert_char_array(len(ascii_units), ascii_units)
 #   Test C_RESFMT, expected value c_resfmt
     stdfRecTest.assert_ubyte(len(c_resfmt))
     stdfRecTest.assert_char_array(len(c_resfmt), c_resfmt)
@@ -267,7 +268,7 @@ def ptr(endian):
 #   Test HI_LIMIT, position 16, value of hi_limit variable
     stdfRecTest.assert_instance_field(inst, 16, hi_limit);
 #   Test UNITS, position 17, value of units variable
-    stdfRecTest.assert_instance_field(inst, 17, units);
+    stdfRecTest.assert_instance_field(inst, 17, ascii_units);
 #   Test C_RESFMT, position 18, value of c_resfmt variable
     stdfRecTest.assert_instance_field(inst, 18, c_resfmt);
 #   Test C_LLMFMT, position 19, value of c_llmfmt variable


### PR DESCRIPTION
Description of the change:
Removing Unicode chars from the STDF, because STDF supports only ASCII.

In the STDF v.4 is written that C*n field type is an ASCII text string which is 7 bit :
'ASCII : (American Standard Code for Information Interchange) A code, using seven bit plus
parity, established by the American National Standards Institute (ANSI) to achieve
compatibility between devices exchanging character oriented data.
 None ASCII characters will be replaced with empty string. Current STDF source code strip all white characters, so if the Unicode char is in the beginning or end of the string, it will be deleted.
 
