### PR TITLE
Update STDR.py

### DIFF
--- a/Semi_ATE/STDF/STDR.py
+++ b/Semi_ATE/STDF/STDR.py
@@ -1641,7 +1641,7 @@ class STDR(ABC):
                             raise STDFError("%s.%s(%s) : Not enough bytes in buffer (need %s while %s available)." % (self.id, method_name,FieldKey, Bytes, len(self.buffer)))
                         working_buffer = self.buffer[0:int(Bytes)]
                         self.buffer = self.buffer[int(Bytes):]
-                        result = working_buffer.decode()
+                        result = working_buffer.decode('utf-8',errors='replace')
                     elif Bytes == 'n': # C*n
                         working_buffer = self.buffer[0:1]
                         self.buffer = self.buffer[1:]
@@ -1650,14 +1650,14 @@ class STDR(ABC):
                             raise STDFError("%s.%s(%s) : Not enough bytes in buffer (need %s while %s available)." % (self.id, FieldKey, n_bytes, len(self.buffer)))
                         working_buffer = self.buffer[0:n_bytes]
                         self.buffer = self.buffer[n_bytes:]
-                        result = working_buffer.decode('utf-8')
+                        result = working_buffer.decode('utf-8',errors='replace')
                     elif Bytes == 'f': # C*f
                         n_bytes = self.get_fields(Ref)[3]
                         if len(self.buffer) < n_bytes:
                             raise STDFError("%s.%s(%s) : Not enough bytes in buffer (need %s while %s available)." % (self.id,method_name, FieldKey, n_bytes, len(self.buffer)))
                         working_buffer = self.buffer[0:n_bytes]
                         self.buffer = self.buffer[n_bytes:]
-                        result = working_buffer.decode()
+                        result = working_buffer.decode('utf-8',errors='replace')
                     else:
                         raise STDFError("%s.%(%s) : Unsupported type '%s'." % (self.id, method_name,FieldKey, '*'.join((Type, Bytes))))
                     if self.local_debug: print("%s.%s(%s)\n   '%s' [%s] -> %s" % (self.id,method_name, FieldKey, self.hexify(pkg), '*'.join((Type, Bytes)), result))


### PR DESCRIPTION
Fixes #77 where invalid UTF-8 characters existing in the STDF DTR records cause UnicodeDecodeError to be thrown when bytearray.decode() is called.

<img width="563" height="45" alt="image" src="https://github.com/user-attachments/assets/d1fa2e8a-e23e-4ef3-a4c6-6dcce398ba3b" />

## Description of Changes
Changed the default error handler of bytearray.decode() from 'strict' to 'replace' in order to handle invalid utf-8 characters that may exist in STDF records

<img width="815" height="500" alt="image" src="https://github.com/user-attachments/assets/01b274b2-c986-4397-ae70-5eea13b3d88c" />


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
Fixes #77
Fixes #54 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
